### PR TITLE
Fix typo - rename `before` query param to `after`

### DIFF
--- a/src/types/page.rs
+++ b/src/types/page.rs
@@ -53,7 +53,7 @@ impl PagingAddressRequestBuilder {
   }
 
   pub fn after(&mut self, t: &str) -> &mut Self {
-    self.params.push(("before".to_owned(), String::from(t)));
+    self.params.push(("after".to_owned(), String::from(t)));
     self
   }
 }


### PR DESCRIPTION
This fixes a small typo by renaming the `before` query param to `after` in the `PagingAddressRequestBuilder::after` method. 