### PR TITLE
fix sample .env and code

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,5 +1,5 @@
 FIREBLOCKS_SECRET="rsa secret"
-FIREBLOCKS_API_KET="your-api-key"
+FIREBLOCKS_API_KEY="your-api-key-file"
 RUST_LOG=info
 # test creation of transactions
 FIREBLOCKS_CREATE_TX=true

--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@
   </a>
 </div>
 
-
 # Overview
 
 `fireblocks_sdk` is an async library for the Fireblocks [API](https://docs.fireblocks.com/api/swagger-ui/#)
 
-!!!! Note this is community driven project and not affiliated with [Fireblocks](https://fireblocks.io) !!!!! 
+!!!! Note this is community driven project and not affiliated with [Fireblocks](https://fireblocks.io) !!!!!
 
-# Getting Started 
+# Getting Started
 
 See developer [portal](https://developers.fireblocks.com/docs/introduction) and sign up for a [sandbox](https://developers.fireblocks.com/docs/sandbox-quickstart) account
 
@@ -36,8 +35,13 @@ use std::time::Duration;
 
 async fn vaults() -> color_eyre::Result<()> {
   let api_key = std::env::var("FIREBLOCKS_API_KEY")?;
-  let secret = std::env::var("FIREBLOCKS_SECRET")?;
+  let secret_file = std::env::var("FIREBLOCKS_SECRET")?;
+  let mut file = File::open(secret_file).expect("file not found");
+  let mut secret: String = String::new();
+  file.read_to_string(&mut secret)
+      .expect("something went wrong reading the file");
   let client = ClientBuilder::new(&api_key, &secret.into_bytes())
+    .with_sandbox()
     .with_timeout(Duration::from_secs(10))
     .with_connect_timeout(Duration::from_secs(5))
     .build()?;
@@ -52,15 +56,19 @@ async fn vaults() -> color_eyre::Result<()> {
 # Development
 
 Create a .env file
+
 ```shell
 cp .env-sameple .env
 ```
+
 Edit .env and configure your API and secret key
 
 Run tests:
+
 ```shell
 cargo test
 ```
+
 ---
 
 # Supported [Endpoints](./SUPPORTED_ENDPOINTS.md)


### PR DESCRIPTION
Hello,

your sample `.env` file contains a typo. On top of that, your sample code doesn't work. You need to load in the key yourself, and you'll get `Error: Unauthorized for /v1/vault/accounts/0 { "message": "Unauthorized: Error getting User certificate", "code": -7} request_id: `. If you use a sandbox account like your README states, `.with_sandbox()` is needed.